### PR TITLE
Fix inverted parameters in failedDownload

### DIFF
--- a/1fichier.sh
+++ b/1fichier.sh
@@ -56,7 +56,7 @@ tcurl() {
 
 failedDownload() {
 	verbosePrint "Write failed links to file"
-	echo "$1" >> "$2/failed.txt"
+	echo "$2" >> "$1/failed.txt"
 }
 
 removeTempDir() {


### PR DESCRIPTION
Seems like during your refactoring you inverted parameters `$1` and `$2` in the failedDownload function.
`$1` is the `baseDir` and `$2` is the `url`.